### PR TITLE
Link the root domain directly without www since it ships the wrong cert

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,4 +9,4 @@ Features that are planned after the rewrite:
 * Allow to sort by different columns, as well as filter by availability (seasonal, temporary etc).
 * Possibly scrape systembolaget website to allow to filter by store location.
 
-[Visit the website.](https://www.alkoholperkrona.nu)
+[Visit the website.](https://alkoholperkrona.nu)


### PR DESCRIPTION
When clicking the link in the readme I'm directed to www.alkoholperkrona.se which ships a cert for github.com (see screenshot) . This leads to an error page being shown in the browser. Likely something is wrongly configured. This pr will change the link in the readme to direct a clicker to the root domain instead

<img width="1073" alt="Screenshot 2020-12-09 at 10 36 46" src="https://user-images.githubusercontent.com/25904359/101612824-5e88b180-3a0b-11eb-9f77-501d7087adb4.png">
